### PR TITLE
Add Copy button for `GoalInfoScreen` notes card

### DIFF
--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -184,13 +184,13 @@ fun ExpandableTextCard(
             FilledTonalButton(onClick = {
                 clipboardManager.setText(AnnotatedString(description))
                 if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-                    Toast.makeText(context, R.string.copy_alert, Toast.LENGTH_SHORT).show()
+                    Toast.makeText(context, R.string.info_copy_alert, Toast.LENGTH_SHORT).show()
                 }
             }) {
                 Row {
-                    Icon(Icons.Filled.ContentCopy, contentDescription = "Copy Notes" )
+                    Icon(Icons.Filled.ContentCopy, contentDescription = stringResource(R.string.info_copy_icon_description))
                     Spacer(Modifier.width(ButtonDefaults.IconSpacing))
-                    Text(text = stringResource(id = R.string.copy))
+                    Text(text = stringResource(id = R.string.info_copy_button))
                 }
             }
         }

--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -25,6 +25,8 @@
 
 package com.starry.greenstash.ui.common
 
+import android.os.Build
+import android.widget.Toast
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -60,6 +62,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -159,6 +162,7 @@ fun ExpandableTextCard(
     showCopyButton: Boolean = false,
     padding: Dp = 12.dp,
 ) {
+    val context = LocalContext.current
     val clipboardManager = LocalClipboardManager.current
 
     ExpandableCard(
@@ -179,6 +183,9 @@ fun ExpandableTextCard(
         if (showCopyButton) {
             FilledTonalButton(onClick = {
                 clipboardManager.setText(AnnotatedString(description))
+                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+                    Toast.makeText(context, R.string.copy_alert, Toast.LENGTH_SHORT).show()
+                }
             }) {
                 Row {
                     Icon(Icons.Filled.ContentCopy, contentDescription = "Copy Notes" )

--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -188,8 +188,7 @@ fun ExpandableTextCard(
                 onClick = {
                     clipboardManager.setText(AnnotatedString(description))
                     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-                        getString(context, R.string.info_copy_alert)
-                            .toToast(context, Toast.LENGTH_SHORT)
+                        getString(context, R.string.info_copy_alert).toToast(context)
                     }
                 },
                 modifier = Modifier.padding(start = 8.dp, top = 8.dp)

--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -36,7 +36,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -189,7 +189,7 @@ fun ExpandableTextCard(
             }) {
                 Row {
                     Icon(Icons.Filled.ContentCopy, contentDescription = "Copy Notes" )
-                    Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                    Spacer(Modifier.width(ButtonDefaults.IconSpacing))
                     Text(text = stringResource(id = R.string.copy))
                 }
             }

--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -183,15 +184,22 @@ fun ExpandableTextCard(
             modifier = Modifier.padding(start = 12.dp, end = 12.dp)
         )
         if (showCopyButton) {
-            FilledTonalButton(onClick = {
-                clipboardManager.setText(AnnotatedString(description))
-                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-                    getString(context, R.string.info_copy_alert)
-                        .toToast(context, Toast.LENGTH_SHORT)
-                }
-            }) {
+            FilledTonalButton(
+                onClick = {
+                    clipboardManager.setText(AnnotatedString(description))
+                    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+                        getString(context, R.string.info_copy_alert)
+                            .toToast(context, Toast.LENGTH_SHORT)
+                    }
+                },
+                modifier = Modifier.padding(start = 8.dp, top = 8.dp)
+            ) {
                 Row {
-                    Icon(Icons.Filled.ContentCopy, contentDescription = stringResource(R.string.info_copy_icon_description))
+                    Icon(
+                        Icons.Filled.ContentCopy,
+                        contentDescription = stringResource(R.string.info_copy_icon_description),
+                        modifier = Modifier.size(ButtonDefaults.IconSize)
+                    )
                     Spacer(Modifier.width(ButtonDefaults.IconSpacing))
                     Text(text = stringResource(id = R.string.info_copy_button))
                 }

--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -31,15 +31,20 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,6 +59,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -147,8 +154,11 @@ fun ExpandableTextCard(
     descriptionFontWeight: FontWeight = FontWeight.Normal,
     descriptionMaxLines: Int = 10,
     shape: Shape = RoundedCornerShape(8.dp),
+    showCopyButton: Boolean = false,
     padding: Dp = 12.dp,
 ) {
+    val clipboardManager = LocalClipboardManager.current
+
     ExpandableCard(
         title = title,
         titleFontSize = titleFontSize,
@@ -164,5 +174,16 @@ fun ExpandableTextCard(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.padding(start = 12.dp, end = 12.dp)
         )
+        if (showCopyButton) {
+            FilledTonalButton(onClick = {
+                clipboardManager.setText(AnnotatedString(description))
+            }) {
+                Row {
+                    Icon(Icons.Filled.ContentCopy, contentDescription = "Copy Notes" )
+                    Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                    Text(text = "Copy")
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -67,6 +68,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.starry.greenstash.R
 
 @ExperimentalMaterial3Api
 @Composable
@@ -181,7 +183,7 @@ fun ExpandableTextCard(
                 Row {
                     Icon(Icons.Filled.ContentCopy, contentDescription = "Copy Notes" )
                     Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                    Text(text = "Copy")
+                    Text(text = stringResource(id = R.string.copy))
                 }
             }
         }

--- a/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/ExpandableCard.kt
@@ -71,7 +71,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat.getString
 import com.starry.greenstash.R
+import com.starry.greenstash.utils.toToast
 
 @ExperimentalMaterial3Api
 @Composable
@@ -184,7 +186,8 @@ fun ExpandableTextCard(
             FilledTonalButton(onClick = {
                 clipboardManager.setText(AnnotatedString(description))
                 if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-                    Toast.makeText(context, R.string.info_copy_alert, Toast.LENGTH_SHORT).show()
+                    getString(context, R.string.info_copy_alert)
+                        .toToast(context, Toast.LENGTH_SHORT)
                 }
             }) {
                 Row {

--- a/app/src/main/java/com/starry/greenstash/ui/screens/info/composables/GoalInfoScreen.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/info/composables/GoalInfoScreen.kt
@@ -399,7 +399,7 @@ fun GoalPriorityCard(goalPriority: GoalPriority, reminders: Boolean) {
 @Composable
 fun GoalNotesCard(notesText: String) {
     ExpandableTextCard(
-        title = stringResource(id = R.string.info_notes_card_title), description = notesText
+        title = stringResource(id = R.string.info_notes_card_title), description = notesText, showCopyButton = true
     )
 }
 

--- a/app/src/main/java/com/starry/greenstash/utils/Extensions.kt
+++ b/app/src/main/java/com/starry/greenstash/utils/Extensions.kt
@@ -76,7 +76,9 @@ fun LazyListState.isScrollingUp(): Boolean {
     }.value
 }
 
-
+/**
+ * Creates and shows a toast message.
+ */
 fun String.toToast(context: Context, length: Int = Toast.LENGTH_SHORT) {
     Toast.makeText(context, this, length).show()
 }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -7,6 +7,7 @@
     <string name="ok">Aceptar</string>
     <string name="unknown_error">¡Vaya! Algo salió mal.</string>
     <string name="copy">Copy</string>
+    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Inicio</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,6 +6,7 @@
     <string name="cancel">Cancelar</string>
     <string name="ok">Aceptar</string>
     <string name="unknown_error">¡Vaya! Algo salió mal.</string>
+    <string name="copy">Copy</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Inicio</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -6,8 +6,6 @@
     <string name="cancel">Cancelar</string>
     <string name="ok">Aceptar</string>
     <string name="unknown_error">¡Vaya! Algo salió mal.</string>
-    <string name="copy">Copy</string>
-    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Inicio</string>
@@ -94,6 +92,9 @@
     <string name="info_goal_no_transactions">Sin transacciones aún.</string>
     <string name="info_edit_transaction_button">Actualizar Transacción</string>
     <string name="info_transaction_onboarding_tip">Consejo: Desliza las transacciones hacia la izquierda o hacia la derecha para editarlas o eliminarlas.</string>
+    <string name="info_copy_button">Copy</string>
+    <string name="info_copy_icon_description">Copy Notes</string>
+    <string name="info_copy_alert">Copied</string>
 
     <!-- Input (New/Edit Goal) Screen -->
     <string name="input_screen_header">¡Es momento de ahorrar!</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -6,6 +6,7 @@
     <string name="cancel">İptal</string>
     <string name="ok">Tamam</string>
     <string name="unknown_error">Hoop! bir şeyler yanlış gitti.</string>
+    <string name="copy">Copy</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Ana Sayfa</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -6,8 +6,6 @@
     <string name="cancel">İptal</string>
     <string name="ok">Tamam</string>
     <string name="unknown_error">Hoop! bir şeyler yanlış gitti.</string>
-    <string name="copy">Copy</string>
-    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Ana Sayfa</string>
@@ -94,6 +92,9 @@
     <string name="info_goal_no_transactions">Henüz İşlem Yok.</string>
     <string name="info_edit_transaction_button">İşlemi Güncelle</string>
     <string name="info_transaction_onboarding_tip">İpucu: İşlemleri düzenlemek veya silmek için sola veya sağa kaydırın.</string>
+    <string name="info_copy_button">Copy</string>
+    <string name="info_copy_icon_description">Copy Notes</string>
+    <string name="info_copy_alert">Copied</string>
 
     <!-- Input (New/Edit Goal) Screen -->
     <string name="input_screen_header">Birikim yapma zamanı!</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -7,6 +7,7 @@
     <string name="ok">Tamam</string>
     <string name="unknown_error">Hoop! bir şeyler yanlış gitti.</string>
     <string name="copy">Copy</string>
+    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Ana Sayfa</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -7,6 +7,7 @@
     <string name="ok">确定</string>
     <string name="unknown_error">糟糕！出了点问题。</string>
     <string name="copy">Copy</string>
+    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">主页</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -6,6 +6,7 @@
     <string name="cancel">取消</string>
     <string name="ok">确定</string>
     <string name="unknown_error">糟糕！出了点问题。</string>
+    <string name="copy">Copy</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">主页</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -6,8 +6,6 @@
     <string name="cancel">取消</string>
     <string name="ok">确定</string>
     <string name="unknown_error">糟糕！出了点问题。</string>
-    <string name="copy">Copy</string>
-    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">主页</string>
@@ -94,6 +92,9 @@
     <string name="info_goal_no_transactions">尚无收支。</string>
     <string name="info_edit_transaction_button">更新交易</string>
     <string name="info_transaction_onboarding_tip">提示：左右滑动交易以编辑或删除它们。</string>
+    <string name="info_copy_button">Copy</string>
+    <string name="info_copy_icon_description">Copy Notes</string>
+    <string name="info_copy_alert">Copied</string>
 
     <!-- Input (New/Edit Goal) Screen -->
     <string name="input_screen_header">省钱时间到！</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,8 +6,6 @@
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
     <string name="unknown_error">Oops! something went wrong.</string>
-    <string name="copy">Copy</string>
-    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Home</string>
@@ -94,6 +92,9 @@
     <string name="info_goal_no_transactions">No Transactions Yet.</string>
     <string name="info_edit_transaction_button">Update Transaction</string>
     <string name="info_transaction_onboarding_tip">Tip: Swipe transactions left or right to edit or delete them.</string>
+    <string name="info_copy_button">Copy</string>
+    <string name="info_copy_icon_description">Copy Notes</string>
+    <string name="info_copy_alert">Copied</string>
 
     <!-- Input (New/Edit Goal) Screen -->
     <string name="input_screen_header">It\'s time to save!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="ok">OK</string>
     <string name="unknown_error">Oops! something went wrong.</string>
     <string name="copy">Copy</string>
+    <string name="copy_alert">Copied</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Home</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="cancel">Cancel</string>
     <string name="ok">OK</string>
     <string name="unknown_error">Oops! something went wrong.</string>
+    <string name="copy">Copy</string>
 
     <!-- Navigation Drawer -->
     <string name="drawer_home">Home</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,7 +94,7 @@
     <string name="info_transaction_onboarding_tip">Tip: Swipe transactions left or right to edit or delete them.</string>
     <string name="info_copy_button">Copy</string>
     <string name="info_copy_icon_description">Copy Notes</string>
-    <string name="info_copy_alert">Copied</string>
+    <string name="info_copy_alert">Copied Successfully!</string>
 
     <!-- Input (New/Edit Goal) Screen -->
     <string name="input_screen_header">It\'s time to save!</string>


### PR DESCRIPTION
Adds a button for copying text from Note card in goal info screen.

Closes #94