### PR TITLE
fix: improve accessibility in settings screen

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsItem.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsItem.kt
@@ -43,10 +43,18 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import com.starry.greenstash.ui.theme.greenstashFont
 import com.starry.greenstash.utils.weakHapticFeedback
+import com.starry.greenstash.R
 
 @Composable
 fun SettingsItem(title: String, description: String, icon: ImageVector, onClick: () -> Unit) {
@@ -97,8 +105,19 @@ fun SettingsItem(
     onCheckChange: (Boolean) -> Unit,
 ) {
     val view = LocalView.current
+    val context = LocalContext.current
     Row(
         modifier = Modifier
+            .clearAndSetSemantics {
+                role = Role.Switch
+                contentDescription = "$title, $description"
+                stateDescription = if (switchState.value) context.getString(R.string.switch_state_open) else context.getString(R.string.switch_state_close)
+                onClick(label = if (switchState.value) context.getString(R.string.switch_action_close) else context.getString(R.string.switch_action_open)) {
+                    view.weakHapticFeedback()
+                    onCheckChange(!switchState.value)
+                    true
+                }
+            }
             .fillMaxWidth()
             .padding(8.dp, 20.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsScreen.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsScreen.kt
@@ -83,6 +83,8 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -127,10 +129,14 @@ fun SettingsScreen(navController: NavController) {
                     fontFamily = greenstashFont
                 )
             }, navigationIcon = {
-                IconButton(onClick = {
-                    view.weakHapticFeedback()
-                    navController.navigateUp()
-                }) {
+                IconButton(
+                    onClick = {
+                        view.weakHapticFeedback()
+                        navController.navigateUp()
+                    },
+                    Modifier.semantics {
+                        onClick(label = context.getString(R.string.navigate_back_desc)) { true }
+                    }) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = null

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -192,6 +192,12 @@
     <string name="app_info_setting">Información de la aplicación</string>
     <string name="app_info_setting_desc">Muestra la versión de la aplicación y enlaces útiles.</string>
 
+    <string name="switch_action_close">Close</string>
+    <string name="switch_action_open">Open</string>
+    <string name="switch_state_close">off</string>
+    <string name="switch_state_open">on</string>
+    <string name="navigate_back_desc">Navigate Back</string>
+
     <!-- Goal Card Style -->
     <string name="goal_card_settings_header">Estilo de la Tarjeta de Objetivo</string>
     <string name="goal_card_settings_tip">¡Consejo! Puedes deslizar una tarjeta con estilo compacto hacia la izquierda o hacia la derecha para editar o eliminar un objetivo de ahorro.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -192,6 +192,12 @@
     <string name="app_info_setting">Informazioni App</string>
     <string name="app_info_setting_desc">Mostra la versione dell\'app e altri link utili.</string>
 
+    <string name="switch_action_close">Close</string>
+    <string name="switch_action_open">Open</string>
+    <string name="switch_state_close">off</string>
+    <string name="switch_state_open">on</string>
+    <string name="navigate_back_desc">Navigate Back</string>
+
     <!-- Goal Card Style -->
     <string name="goal_card_settings_header">Stile Obbiettivo</string>
     <string name="goal_card_settings_tip">Suggerimento! Puoi scorrere una scheda in stile compatto a sinistra o destra per modificare o eliminare un obbiettivo di risparmio.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -190,6 +190,12 @@
     <string name="app_info_setting">Informações do Aplicativo</string>
     <string name="app_info_setting_desc">Mostrar versão do aplicativo e links úteis.</string>
 
+    <string name="switch_action_close">Close</string>
+    <string name="switch_action_open">Open</string>
+    <string name="switch_state_close">off</string>
+    <string name="switch_state_open">on</string>
+    <string name="navigate_back_desc">Navigate Back</string>
+
     <!-- Goal Card Style -->
     <string name="goal_card_settings_header">Estilo da Meta</string>
     <string name="goal_card_settings_tip">Dica! Você pode deslizar um cartão estilizado compacto para a esquerda ou direita para editar ou excluir uma meta de economia.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -192,6 +192,12 @@
     <string name="app_info_setting">Информация о приложении</string>
     <string name="app_info_setting_desc">Показать версию приложения и полезные ссылки.</string>
 
+    <string name="switch_action_close">Close</string>
+    <string name="switch_action_open">Open</string>
+    <string name="switch_state_close">off</string>
+    <string name="switch_state_open">on</string>
+    <string name="navigate_back_desc">Navigate Back</string>
+
     <!-- Goal Card Style -->
     <string name="goal_card_settings_header">Стиль цели</string>
     <string name="goal_card_settings_tip">Совет! Чтобы изменить или удалить цель накоплений, можно провести пальцем по компактной карточке влево или вправо.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -194,6 +194,12 @@
     <string name="app_info_setting">Uygulama Bilgileri</string>
     <string name="app_info_setting_desc">Uygulama versiyonunu ve faydalı linkleri göster.</string>
 
+    <string name="switch_action_close">Close</string>
+    <string name="switch_action_open">Open</string>
+    <string name="switch_state_close">off</string>
+    <string name="switch_state_open">on</string>
+    <string name="navigate_back_desc">Navigate Back</string>
+
     <!-- Goal Card Style -->
     <string name="goal_card_settings_header">Hedef Stili</string>
     <string name="goal_card_settings_tip">İpucu! Kompakt tarzda bir kartı sola veya sağa kaydırarak bir tasarruf hedefini düzenleyebilir veya silebilirsiniz.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -191,6 +191,11 @@
     <string name="license_setting_desc">显示开源许可协议信息。</string>
     <string name="app_info_setting">应用信息</string>
     <string name="app_info_setting_desc">显示应用版本和有用的链接。</string>
+    <string name="switch_action_close">关闭</string>
+    <string name="switch_action_open">打开</string>
+    <string name="switch_state_close">已关闭</string>
+    <string name="switch_state_open">已打开</string>
+    <string name="navigate_back_desc">返回</string>
 
     <!-- Goal Card STyle -->
     <string name="goal_card_settings_header">目标样式</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -191,6 +191,12 @@
     <string name="app_info_setting">應用程式資訊</string>
     <string name="app_info_setting_desc">顯示應用程式版本和連結。</string>
 
+    <string name="switch_action_close">Close</string>
+    <string name="switch_action_open">Open</string>
+    <string name="switch_state_close">off</string>
+    <string name="switch_state_open">on</string>
+    <string name="navigate_back_desc">Navigate Back</string>
+
     <!-- Goal Card Style -->
     <string name="goal_card_settings_header">目標樣式</string>
     <string name="goal_card_settings_tip">提示！您可以向左或向右滑動緊湊樣式的卡片以編輯或刪除儲蓄目標。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -191,6 +191,11 @@
     <string name="license_setting_desc">Show open source license information.</string>
     <string name="app_info_setting">App Information</string>
     <string name="app_info_setting_desc">Show app version and useful links.</string>
+    <string name="switch_action_close">Close</string>
+    <string name="switch_action_open">Open</string>
+    <string name="switch_state_close">off</string>
+    <string name="switch_state_open">on</string>
+    <string name="navigate_back_desc">Navigate Back</string>
 
     <!-- Goal Card Style -->
     <string name="goal_card_settings_header">Goal Style</string>


### PR DESCRIPTION
### Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
**Add an `onClickLabel` to the back button in the top-left corner of the settings screen.** Before this change, when TalkBack focused on this button, it would announce: "Button, Double click to activate". After the change, it now announces: "Button, Double click to navigate back". I believe this improves accessibility. However, I’m not entirely sure whether it’s appropriate to make too many changes in a single pull request, nor am I certain if my proposed changes fully align with the project’s guidelines. So for now, I’ve only updated the back button on the Settings Screen.

**Added accessibility support for `SettingsItem`.** Taking the `Biometric Lock` feature as an example, before the change, when a visually impaired user accessed this item, the announcement order was: "`Biometric Lock` → swipe right → `off, Switch, Double tab to activate` → swipe right → `Use your fingerprint or screen lock password to unlock Greenstash` → swipe right". This order didn’t clearly convey the relationship between the label, the switch, and the description, which could confuse users.

![Screenshot_1750066641](https://github.com/user-attachments/assets/f71e38bf-45ac-437e-81ad-ef991a25f231)

After the change, visually impaired users can now access the entire row as a single item. The screen reader will announce:  "`off, Biometric Lock, Use your fingerprint or screen lock password to unlock Greenstash, Switch, Double tab to Open`". This modification does not affect the interaction for sighted users — the Switch still functions as before, and users can tap it to turn the feature on or off.

![Screenshot_1750066974](https://github.com/user-attachments/assets/5cdf9996-22f8-4e8c-ac98-083f575c435d)

Since I added some strings in `string.xml` and only understand English and Chinese, I added the English versions in other language files to pass CI. I'm not sure if this approach is fully compliant with the project's guidelines. If there are any issues or this doesn't meet the required standards, please feel free to reject the PR — I’ll be happy to make the necessary corrections.

### Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Pool-Of-Tears/GreenStash/issues/170

## Type of change

<!--- Is this a bug fix, adding a feature... -->
bug fix

### Pull Request checklist

<!-- Before submitting the PR, please address each item. Use [x] to check the boxes -->

- [x] The commit message uses the [conventional commiting method][conv-commits].
- [x] Made sure that your PR is not duplicate
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not (for bug
  fixes/features). Your PR should pass all CI checks in our Gtihub
  Actions [Workflow](https://github.com/Pool-Of-Tears/GreenStash/actions)
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of
  why it does not (*optional*)

[conv-commits]:https://kapeli.com/cheat_sheets/Conventional_Commits.docset/Contents/Resources/Documents/index