### PR TITLE
feat: make date-picker show selected date when editing goals & more

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -37,6 +37,10 @@
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="PreviewDeviceShouldUseNewSpec" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
@@ -58,6 +62,10 @@
       <option name="previewFile" value="true" />
     </inspection_tool>
     <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
       <option name="previewFile" value="true" />
     </inspection_tool>

--- a/app/src/main/java/com/starry/greenstash/ui/screens/archive/composables/ArchiveScreenComponents.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/archive/composables/ArchiveScreenComponents.kt
@@ -164,34 +164,34 @@ fun ArchiveDialogs(
     if (showRestoreDialog.value) {
         AlertDialog(
             onDismissRequest = {
-            showRestoreDialog.value = false
-        }, title = {
-            Text(
-                text = stringResource(id = R.string.goal_restore_confirmation),
-                color = MaterialTheme.colorScheme.onSurface,
-                fontFamily = greenstashFont,
-                fontSize = 18.sp
-            )
-        }, confirmButton = {
-            FilledTonalButton(
-                onClick = {
-                    showRestoreDialog.value = false
-                    onRestoreConfirmed()
-                },
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            ) {
-                Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
-            }
-        }, dismissButton = {
-            TextButton(onClick = {
                 showRestoreDialog.value = false
-            }) {
-                Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
-            }
-        },
+            }, title = {
+                Text(
+                    text = stringResource(id = R.string.goal_restore_confirmation),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontFamily = greenstashFont,
+                    fontSize = 18.sp
+                )
+            }, confirmButton = {
+                FilledTonalButton(
+                    onClick = {
+                        showRestoreDialog.value = false
+                        onRestoreConfirmed()
+                    },
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                ) {
+                    Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
+                }
+            }, dismissButton = {
+                TextButton(onClick = {
+                    showRestoreDialog.value = false
+                }) {
+                    Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
+                }
+            },
             icon = {
                 Icon(
                     imageVector = Icons.Filled.Refresh,
@@ -204,34 +204,34 @@ fun ArchiveDialogs(
     if (showDeleteDialog.value) {
         AlertDialog(
             onDismissRequest = {
-            showDeleteDialog.value = false
-        }, title = {
-            Text(
-                text = stringResource(id = R.string.goal_delete_confirmation),
-                color = MaterialTheme.colorScheme.onSurface,
-                fontFamily = greenstashFont,
-                fontSize = 18.sp
-            )
-        }, confirmButton = {
-            FilledTonalButton(
-                onClick = {
-                    showDeleteDialog.value = false
-                    onDeleteConfirmed()
-                },
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    contentColor = MaterialTheme.colorScheme.onErrorContainer
-                )
-            ) {
-                Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
-            }
-        }, dismissButton = {
-            TextButton(onClick = {
                 showDeleteDialog.value = false
-            }) {
-                Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
-            }
-        },
+            }, title = {
+                Text(
+                    text = stringResource(id = R.string.goal_delete_confirmation),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontFamily = greenstashFont,
+                    fontSize = 18.sp
+                )
+            }, confirmButton = {
+                FilledTonalButton(
+                    onClick = {
+                        showDeleteDialog.value = false
+                        onDeleteConfirmed()
+                    },
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                ) {
+                    Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
+                }
+            }, dismissButton = {
+                TextButton(onClick = {
+                    showDeleteDialog.value = false
+                }) {
+                    Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
+                }
+            },
             icon = {
                 Icon(
                     imageVector = Icons.Outlined.Delete,

--- a/app/src/main/java/com/starry/greenstash/ui/screens/home/composables/HomeDialogs.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/home/composables/HomeDialogs.kt
@@ -53,34 +53,34 @@ fun HomeDialogs(
 
         AlertDialog(
             onDismissRequest = {
-            openDeleteDialog.value = false
-        }, title = {
-            Text(
-                text = stringResource(id = R.string.goal_delete_confirmation),
-                color = MaterialTheme.colorScheme.onSurface,
-                fontFamily = greenstashFont,
-                fontSize = 18.sp
-            )
-        }, confirmButton = {
-            FilledTonalButton(
-                onClick = {
-                    openDeleteDialog.value = false
-                    onDeleteConfirmed()
-                },
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    contentColor = MaterialTheme.colorScheme.onErrorContainer
-                )
-            ) {
-                Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
-            }
-        }, dismissButton = {
-            TextButton(onClick = {
                 openDeleteDialog.value = false
-            }) {
-                Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
-            }
-        },
+            }, title = {
+                Text(
+                    text = stringResource(id = R.string.goal_delete_confirmation),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontFamily = greenstashFont,
+                    fontSize = 18.sp
+                )
+            }, confirmButton = {
+                FilledTonalButton(
+                    onClick = {
+                        openDeleteDialog.value = false
+                        onDeleteConfirmed()
+                    },
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                ) {
+                    Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
+                }
+            }, dismissButton = {
+                TextButton(onClick = {
+                    openDeleteDialog.value = false
+                }) {
+                    Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
+                }
+            },
             icon = {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_goal_delete),
@@ -94,34 +94,34 @@ fun HomeDialogs(
 
         AlertDialog(
             onDismissRequest = {
-            openArchiveDialog.value = false
-        }, title = {
-            Text(
-                text = stringResource(id = R.string.goal_archive_confirmation),
-                color = MaterialTheme.colorScheme.onSurface,
-                fontFamily = greenstashFont,
-                fontSize = 18.sp
-            )
-        }, confirmButton = {
-            FilledTonalButton(
-                onClick = {
-                    openArchiveDialog.value = false
-                    onArchiveConfirmed()
-                },
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                )
-            ) {
-                Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
-            }
-        }, dismissButton = {
-            TextButton(onClick = {
                 openArchiveDialog.value = false
-            }) {
-                Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
-            }
-        },
+            }, title = {
+                Text(
+                    text = stringResource(id = R.string.goal_archive_confirmation),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontFamily = greenstashFont,
+                    fontSize = 18.sp
+                )
+            }, confirmButton = {
+                FilledTonalButton(
+                    onClick = {
+                        openArchiveDialog.value = false
+                        onArchiveConfirmed()
+                    },
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
+                ) {
+                    Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
+                }
+            }, dismissButton = {
+                TextButton(onClick = {
+                    openArchiveDialog.value = false
+                }) {
+                    Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
+                }
+            },
             icon = {
                 Icon(
                     imageVector = ImageVector.vectorResource(id = R.drawable.ic_compact_goal_archve),

--- a/app/src/main/java/com/starry/greenstash/ui/screens/info/composables/TransactionItems.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/info/composables/TransactionItems.kt
@@ -152,33 +152,33 @@ private fun TransactionItem(
     if (showDeleteDialog.value) {
         AlertDialog(
             onDismissRequest = {
-            showDeleteDialog.value = false
-        }, title = {
-            Text(
-                text = stringResource(id = R.string.goal_delete_confirmation),
-                color = MaterialTheme.colorScheme.onSurface,
-                fontFamily = greenstashFont,
-            )
-        }, confirmButton = {
-            FilledTonalButton(
-                onClick = {
-                    showDeleteDialog.value = false
-                    viewModel.deleteTransaction(transaction)
-                },
-                colors = ButtonDefaults.filledTonalButtonColors(
-                    containerColor = MaterialTheme.colorScheme.errorContainer,
-                    contentColor = MaterialTheme.colorScheme.onErrorContainer
-                )
-            ) {
-                Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
-            }
-        }, dismissButton = {
-            TextButton(onClick = {
                 showDeleteDialog.value = false
-            }) {
-                Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
-            }
-        },
+            }, title = {
+                Text(
+                    text = stringResource(id = R.string.goal_delete_confirmation),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontFamily = greenstashFont,
+                )
+            }, confirmButton = {
+                FilledTonalButton(
+                    onClick = {
+                        showDeleteDialog.value = false
+                        viewModel.deleteTransaction(transaction)
+                    },
+                    colors = ButtonDefaults.filledTonalButtonColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                ) {
+                    Text(stringResource(id = R.string.confirm), fontFamily = greenstashFont)
+                }
+            }, dismissButton = {
+                TextButton(onClick = {
+                    showDeleteDialog.value = false
+                }) {
+                    Text(stringResource(id = R.string.cancel), fontFamily = greenstashFont)
+                }
+            },
             icon = {
                 Icon(imageVector = Icons.Rounded.Delete, contentDescription = null)
             }

--- a/app/src/main/java/com/starry/greenstash/ui/screens/input/composables/InputScreen.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/input/composables/InputScreen.kt
@@ -143,6 +143,7 @@ import com.starry.greenstash.ui.screens.input.InputViewModel
 import com.starry.greenstash.ui.theme.greenstashFont
 import com.starry.greenstash.utils.ImageUtils
 import com.starry.greenstash.utils.NumberUtils
+import com.starry.greenstash.utils.Utils
 import com.starry.greenstash.utils.displayName
 import com.starry.greenstash.utils.getActivity
 import com.starry.greenstash.utils.hasNotificationPermission
@@ -191,6 +192,16 @@ fun InputScreen(editGoalId: String?, navController: NavController) {
                     }
                 })
         })
+        LaunchedEffect(true) {
+            delay(500L)
+            selectedDate.value = viewModel.state.deadline
+                .takeIf { it.isNotEmpty() }
+                ?.let { deadline ->
+                    Utils.parseDateStyle(deadline)?.let { style ->
+                        LocalDate.parse(deadline, DateTimeFormatter.ofPattern(style.pattern))
+                    }
+                } ?: LocalDate.now()
+        }
         topBarText = stringResource(id = R.string.input_edit_goal_header)
         buttonText = stringResource(id = R.string.input_edit_goal_button)
     } else {
@@ -705,7 +716,8 @@ private fun GoalPriorityMenu(selectedPriority: String, onPriorityChanged: (Strin
                         shape = RectangleShape,
                         label = {
                             Text(
-                                text = GoalPriority.Normal.displayName(), fontFamily = greenstashFont
+                                text = GoalPriority.Normal.displayName(),
+                                fontFamily = greenstashFont
                             )
                         },
                         icon = {
@@ -818,23 +830,23 @@ private fun GoalReminderMenu(
             Spacer(modifier = Modifier.weight(1f))
             Switch(
                 checked = reminderState, onCheckedChange = { newValue ->
-                view.weakHapticFeedback()
-                onReminderChanged(newValue)
-                // Ask for notification permission if android ver > 13.
-                if (newValue && !hasNotificationPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                }
-            }, thumbContent = if (reminderState) {
-                {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = null,
-                        modifier = Modifier.size(SwitchDefaults.IconSize),
-                    )
-                }
-            } else {
-                null
-            }, modifier = modifier)
+                    view.weakHapticFeedback()
+                    onReminderChanged(newValue)
+                    // Ask for notification permission if android ver > 13.
+                    if (newValue && !hasNotificationPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                }, thumbContent = if (reminderState) {
+                    {
+                        Icon(
+                            imageVector = Icons.Filled.Check,
+                            contentDescription = null,
+                            modifier = Modifier.size(SwitchDefaults.IconSize),
+                        )
+                    }
+                } else {
+                    null
+                }, modifier = modifier)
         }
     }
 }

--- a/app/src/main/java/com/starry/greenstash/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/settings/SettingsViewModel.kt
@@ -65,11 +65,13 @@ class SettingsViewModel @Inject constructor(
     private val _amoledTheme = MutableLiveData(false)
     private val _materialYou = MutableLiveData(Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
     private val _goalCardStyle = MutableLiveData(GoalCardStyle.Classic)
+    private val _dateStyle = MutableLiveData<DateStyle>(DateStyle.DateMonthYear)
 
     val theme: LiveData<ThemeMode> = _theme
     val amoledTheme: LiveData<Boolean> = _amoledTheme
     val materialYou: LiveData<Boolean> = _materialYou
     val goalCardStyle: LiveData<GoalCardStyle> = _goalCardStyle
+    val dateStyle: LiveData<DateStyle> = _dateStyle
 
     // Initialize preferences --------------------------------------------
     init {
@@ -77,6 +79,11 @@ class SettingsViewModel @Inject constructor(
         _amoledTheme.value = getAmoledThemeValue()
         _materialYou.value = getMaterialYouValue()
         _goalCardStyle.value = GoalCardStyle.entries.toTypedArray()[getGoalCardStyleValue()]
+        _dateStyle.value = when (getDateStyleValue()) {
+            DateStyle.DateMonthYear.pattern -> DateStyle.DateMonthYear
+            DateStyle.YearMonthDate.pattern -> DateStyle.YearMonthDate
+            else -> DateStyle.DateMonthYear
+        }
     }
 
     // Setters for preferences --------------------------------------------
@@ -101,6 +108,12 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun setDateStyle(newValue: String) {
+        val dateStyle = when (newValue) {
+            DateStyle.DateMonthYear.pattern -> DateStyle.DateMonthYear
+            DateStyle.YearMonthDate.pattern -> DateStyle.YearMonthDate
+            else -> DateStyle.DateMonthYear
+        }
+        _dateStyle.postValue(dateStyle)
         preferenceUtil.putString(PreferenceUtil.DATE_FORMAT_STR, newValue)
     }
 
@@ -113,25 +126,6 @@ class SettingsViewModel @Inject constructor(
     }
 
     // Getters for preferences --------------------------------------------
-    fun getThemeValue() = preferenceUtil.getInt(
-        PreferenceUtil.APP_THEME_INT, ThemeMode.Auto.ordinal
-    )
-
-    fun getAmoledThemeValue() = preferenceUtil.getBoolean(
-        PreferenceUtil.AMOLED_THEME_BOOL, false
-    )
-
-    fun getMaterialYouValue() = preferenceUtil.getBoolean(
-        PreferenceUtil.MATERIAL_YOU_BOOL, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
-    )
-
-    fun getGoalCardStyleValue() = preferenceUtil.getInt(
-        PreferenceUtil.GOAL_CARD_STYLE_INT, GoalCardStyle.Classic.ordinal
-    )
-
-    fun getDateStyleValue() = preferenceUtil.getString(
-        PreferenceUtil.DATE_FORMAT_STR, DateStyle.DateMonthYear.pattern
-    )
 
     fun getDefaultCurrencyValue() = preferenceUtil.getString(
         PreferenceUtil.DEFAULT_CURRENCY_STR, "USD"
@@ -153,4 +147,30 @@ class SettingsViewModel @Inject constructor(
             if (isSystemInDarkTheme()) ThemeMode.Dark else ThemeMode.Light
         } else theme.value!!
     }
+
+
+    // Only used in init block
+    private fun getThemeValue() = preferenceUtil.getInt(
+        PreferenceUtil.APP_THEME_INT, ThemeMode.Auto.ordinal
+    )
+
+    // Only used in init block
+    private fun getAmoledThemeValue() = preferenceUtil.getBoolean(
+        PreferenceUtil.AMOLED_THEME_BOOL, false
+    )
+
+    // Only used in init block
+    private fun getMaterialYouValue() = preferenceUtil.getBoolean(
+        PreferenceUtil.MATERIAL_YOU_BOOL, Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+    )
+
+    // Only used in init block
+    private fun getGoalCardStyleValue() = preferenceUtil.getInt(
+        PreferenceUtil.GOAL_CARD_STYLE_INT, GoalCardStyle.Classic.ordinal
+    )
+
+    // Only used in init block
+    private fun getDateStyleValue() = preferenceUtil.getString(
+        PreferenceUtil.DATE_FORMAT_STR, DateStyle.DateMonthYear.pattern
+    )
 }

--- a/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/GoalCardStyle.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/GoalCardStyle.kt
@@ -194,7 +194,9 @@ fun GoalCardStyle(navController: NavController) {
                             GoalItemCompact(
                                 title = stringResource(R.string.preview_example_title),
                                 savedAmount = NumberUtils.formatCurrency(1000.00, currency),
-                                daysLeftText = stringResource(R.string.info_card_remaining_days).format(12),
+                                daysLeftText = stringResource(R.string.info_card_remaining_days).format(
+                                    12
+                                ),
                                 goalProgress = 0.8f,
                                 goalIcon = ImageVector.vectorResource(id = R.drawable.ic_nav_rating),
                                 isGoalCompleted = false,

--- a/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsItem.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsItem.kt
@@ -39,7 +39,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -101,7 +101,7 @@ fun SettingsItem(
     title: String,
     description: String,
     icon: ImageVector,
-    switchState: MutableState<Boolean>,
+    switchState: State<Boolean>,
     onCheckChange: (Boolean) -> Unit,
 ) {
     val view = LocalView.current

--- a/app/src/main/java/com/starry/greenstash/utils/Utils.kt
+++ b/app/src/main/java/com/starry/greenstash/utils/Utils.kt
@@ -33,6 +33,8 @@ import android.os.Build
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
+import androidx.core.net.toUri
+import com.starry.greenstash.ui.screens.settings.DateStyle
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -82,13 +84,34 @@ object Utils {
     }
 
     /**
+     * Detects the DateStyle of a given date string based on its format.
+     *
+     * Assumes date is separated by "/".
+     *
+     * @param dateStr String (date in string format)
+     * @return DateStyle (detected style), or null if unknown
+     */
+    fun parseDateStyle(dateStr: String): DateStyle? {
+        val parts = dateStr.split("/")
+        if (parts.size != 3) return null
+        return when (parts[0].length) {
+            // Case: starts with YYYY
+            4 -> DateStyle.YearMonthDate
+            // Case: starts with DD (common dd/MM/yyyy)
+            2 -> DateStyle.DateMonthYear
+            // Unsupported format
+            else -> null
+        }
+    }
+
+    /**
      * Open the web link in the browser.
      *
      * @param context The context
      * @param url The URL to open
      */
     fun openWebLink(context: Context, url: String) {
-        val uri: Uri = Uri.parse(url)
+        val uri: Uri = url.toUri()
         val intent = Intent(Intent.ACTION_VIEW, uri)
         try {
             context.startActivity(intent)


### PR DESCRIPTION
- Date picker in goal editing now defaults to the selected date instead of the current date
- Fixed date style option in settings not reflecting changes until reloading the screen
- Cleaned up redundant settings screen states for simpler, more maintainable code