### PR TITLE
README.md: add link to Weblate translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ Contributions are welcome!
 
 <h2 align="center">Translations</h2>
 
-If you want to make the app available in your language, you're welcome to create a pull request with
+Please help to translate the app on [Weblate](https://toolate.othing.xyz/projects/greenstash/).
+
+<a href="https://toolate.othing.xyz/projects/greenstash/">
+<img src="https://toolate.othing.xyz/widget/greenstash/multi-auto.svg" alt="Translation status" />
+</a>
+
+You can also translate manually and create a pull request with
 your translation file. The base string resources can be found under:
 
 ```


### PR DESCRIPTION
In the #116 was discussed need for integrating a translation platform.
There is the Toolate server of Weblate that is open for F-Droid projects and this is currently the best option.
I registered the translation project for you there https://toolate.othing.xyz/projects/greenstash/  

You can translate the Android app strings and the app's description in F-Droid and PlayStore.
Once a day it will collect all translations into one commit and send in a PR like the #186. You may merge the PR once before a release, or even pull the changes manually from the git.

If you wish I can add you as the project admin (needed to send announcements about translations freeze before release or resolving of conflicts).

In the PR I added link to the Weblate instance.