### PR TITLE
fix: Fix Currency picker state resetting in onboarding screen on screen rotation

### DIFF
--- a/app/src/main/java/com/starry/greenstash/ui/common/CurrencyPicker.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/CurrencyPicker.kt
@@ -51,8 +51,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -108,10 +108,10 @@ fun CurrencyPicker(
     val currencyValues = currencyPickerData.currencyValues
 
     val defaultCurrencyEntry = currencyNames[currencyValues.indexOf(defaultCurrencyValue)]
-    val (selectedCurrencyOption, onCurrencyOptionSelected) = remember {
+    val (selectedCurrencyOption, onCurrencyOptionSelected) = rememberSaveable {
         mutableStateOf(defaultCurrencyEntry)
     }
-    val (searchText, onSearchTextChanged) = remember { mutableStateOf("") }
+    val (searchText, onSearchTextChanged) = rememberSaveable { mutableStateOf("") }
     val filteredCurrencies = currencyNames.filter { it.contains(searchText, ignoreCase = true) }
 
     val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/com/starry/greenstash/ui/common/SlideInContainer.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/common/SlideInContainer.kt
@@ -35,7 +35,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import kotlinx.coroutines.delay
 
@@ -44,7 +44,7 @@ fun SlideInAnimatedContainer(
     initialDelay: Long, content:
     @Composable () -> Unit
 ) {
-    val showContent = remember { mutableStateOf(false) }
+    val showContent = rememberSaveable { mutableStateOf(false) }
     LaunchedEffect(key1 = true) {
         delay(initialDelay)
         showContent.value = true

--- a/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsScreen.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/settings/composables/SettingsScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -337,20 +338,20 @@ private fun LocaleSettings(viewModel: SettingsViewModel) {
     val context = LocalContext.current
     // Date related values.
     val dateValue = dateStyleToDisplayFormat(viewModel.dateStyle.observeAsState().value!!)
-    val dateDialog = remember { mutableStateOf(false) }
+    val dateDialog = rememberSaveable { mutableStateOf(false) }
     val dateRadioOptions = DateStyle.entries.map { dateStyleToDisplayFormat(it) }
-    val (selectedDateOption, onDateOptionSelected) = remember {
+    val (selectedDateOption, onDateOptionSelected) = rememberSaveable {
         mutableStateOf(dateValue)
     }
 
     // Currency related values.
-    val currencyDialog = remember { mutableStateOf(false) }
+    val currencyDialog = rememberSaveable { mutableStateOf(false) }
     val currencyNames =
         context.applicationContext.resources.getStringArray(R.array.currency_names)
     val currencyValues =
         context.applicationContext.resources.getStringArray(R.array.currency_values)
 
-    val selectedCurrencyName = remember {
+    val selectedCurrencyName = rememberSaveable {
         mutableStateOf(currencyNames[currencyValues.indexOf(viewModel.getDefaultCurrencyValue())])
     }
 

--- a/app/src/main/java/com/starry/greenstash/ui/screens/welcome/composables/WelcomeScreen.kt
+++ b/app/src/main/java/com/starry/greenstash/ui/screens/welcome/composables/WelcomeScreen.kt
@@ -48,7 +48,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -81,14 +81,14 @@ fun WelcomeScreen(navController: NavController) {
     val context = LocalContext.current
     val viewModel: WelcomeViewModel = hiltViewModel()
 
-    val currencyDialog = remember { mutableStateOf(false) }
+    val currencyDialog = rememberSaveable { mutableStateOf(false) }
     val currencyNames =
         context.applicationContext.resources.getStringArray(R.array.currency_names)
     val currencyValues =
         context.applicationContext.resources.getStringArray(R.array.currency_values)
 
 
-    val selectedCurrencyName = remember {
+    val selectedCurrencyName = rememberSaveable {
         mutableStateOf(currencyNames[currencyValues.indexOf(viewModel.getDefaultCurrencyValue())])
     }
 


### PR DESCRIPTION
Closes #213 